### PR TITLE
Feature/89/pyqt main thread

### DIFF
--- a/BaseStation/src/controller.py
+++ b/BaseStation/src/controller.py
@@ -53,7 +53,7 @@ class Controller(MessageSender):
 
     def update_plots(self):
         self.data_widget.draw_altitude(self.consumer["time_stamp"], self.consumer["altitude_feet"])
-        self.data_widget.draw_apogee(self.consumer["apogee"])
+        self.data_widget.draw_apogee(self.consumer.get_apogee())
         self.data_widget.draw_map(*self.consumer.get_projected_coordinates())
         self.data_widget.show_current_coordinates(self.consumer.get_last_gps_coordinates())
         self.data_widget.draw_voltage(self.consumer["voltage"])

--- a/BaseStation/src/controller_factory.py
+++ b/BaseStation/src/controller_factory.py
@@ -1,5 +1,7 @@
 import threading
 
+from PyQt5.QtCore import QTimer
+
 from src.config import ConfigLoader
 from src.data_processing.consumer_factory import ConsumerFactory
 from src.data_processing.gps.coordinate_conversion_strategy_factory import CoordinateConversionStrategyFactory
@@ -44,7 +46,7 @@ class ControllerFactory:
 
         save_manager = SaveManager(data_producer, real_time_widget)
 
-        return RealTimeController(real_time_widget, data_producer, consumer_factory, save_manager, config)
+        return RealTimeController(real_time_widget, data_producer, consumer_factory, save_manager, config, QTimer())
 
     def create_replay_controller(self, replay_widget: ReplayWidget):
         config = ConfigLoader.load()
@@ -56,4 +58,4 @@ class ControllerFactory:
 
         consumer_factory = ConsumerFactory(self.coordinate_conversion_strategy_factory, self.gps_fix_validator_factory)
 
-        return ReplayController(replay_widget, data_producer, consumer_factory, config)
+        return ReplayController(replay_widget, data_producer, consumer_factory, config, QTimer())

--- a/BaseStation/src/data_processing/apogee.py
+++ b/BaseStation/src/data_processing/apogee.py
@@ -1,0 +1,37 @@
+class Apogee:
+    def __init__(self, timestamp: float, altitude: float):
+        self._timestamp = timestamp
+        self._altitude = altitude
+        self._is_reached = True
+
+    @property
+    def timestamp(self) -> float:
+        return self._timestamp
+
+    @property
+    def altitude(self) -> float:
+        return self._altitude
+
+    @property
+    def is_reached(self) -> bool:
+        return self._is_reached
+
+    @staticmethod
+    def unreached():
+        apogee = Apogee(0, 0)
+        apogee._is_reached = False
+
+        return apogee
+
+    def __eq__(self, other):
+        if not isinstance(other, Apogee):
+            return False
+
+        return (self._timestamp == other.timestamp and self._altitude == other.altitude and
+                self._is_reached == other.is_reached)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash((self._timestamp, self._altitude, self._is_reached))

--- a/BaseStation/src/data_processing/apogee_calculator.py
+++ b/BaseStation/src/data_processing/apogee_calculator.py
@@ -1,12 +1,15 @@
+from src.data_processing.apogee import Apogee
+
+
 class ApogeeCalculator:
     def __init__(self):
-        self.apogee = 0
+        self.apogee = Apogee.unreached()
         self.apogee_index = 0
 
         self.last_altitude_index = 0
 
-    def update(self, values: list):
-        length = len(values)
+    def update(self, timestamps: list, altitudes: list):
+        length = len(altitudes)
 
         if length < 2 or length < self.apogee_index:
             self.set_value_none()
@@ -17,9 +20,9 @@ class ApogeeCalculator:
 
         if self.check_change_apogee(length):
             for i in range(self.last_altitude_index, length-1):
-                if values[i] > 0 and values[i] >= self.apogee:
-                    if (values[i] - values[i + 1]) >= 0:
-                        self.apogee = values[i]
+                if altitudes[i] > 0 and altitudes[i] >= self.apogee.altitude:
+                    if (altitudes[i] - altitudes[i + 1]) >= 0:
+                        self.apogee = Apogee(timestamps[i], altitudes[i])
                         self.apogee_index = i
         else:
             self.set_value_none()
@@ -27,10 +30,10 @@ class ApogeeCalculator:
         self.last_altitude_index = length-1
 
     def check_change_apogee(self, length: int):
-        return self.apogee_index < length or self.last_altitude_index == 0 or self.apogee == 0
+        return self.apogee_index < length or self.last_altitude_index == 0 or self.apogee.altitude == 0
 
     def set_value_none(self):
-        self.apogee = 0
+        self.apogee = Apogee.unreached()
         self.apogee_index = 0
 
     def reset(self):
@@ -39,8 +42,4 @@ class ApogeeCalculator:
         self.last_altitude_index = 0
 
     def get_apogee(self):
-        if self.apogee_index is not 0:
-            rep = (self.apogee_index, self.apogee)
-            return rep
-
-        return None
+        return self.apogee

--- a/BaseStation/src/replay_controller.py
+++ b/BaseStation/src/replay_controller.py
@@ -1,3 +1,5 @@
+from PyQt5.QtCore import QTimer
+
 from src.config import Config
 from src.controller import Controller
 from src.data_processing.consumer_factory import ConsumerFactory
@@ -7,8 +9,8 @@ from src.ui.replay_widget import ReplayWidget
 
 class ReplayController(Controller):
     def __init__(self, replay_widget: ReplayWidget, file_data_producer: FileDataProducer,
-                 consumer_factory: ConsumerFactory, config: Config):
-        super().__init__(replay_widget, file_data_producer, consumer_factory, config)
+                 consumer_factory: ConsumerFactory, config: Config, timer: QTimer):
+        super().__init__(replay_widget, file_data_producer, consumer_factory, config, timer)
 
         self.data_widget.set_callback("play_pause", self.play_pause_button_callback)
         self.data_widget.set_callback("fast_forward", self.fast_forward_button_callback)
@@ -31,7 +33,7 @@ class ReplayController(Controller):
     def _play(self):
         self.data_producer.restart()
         if not self.is_running:
-            self.start_thread()
+            self.start_updates()
         self.data_widget.set_pause_button_text()
 
     def _pause(self):
@@ -65,7 +67,7 @@ class ReplayController(Controller):
 
     def deactivate(self) -> bool:
         if self.is_running:
-            self.stop_thread()
+            self.stop_updates()
 
         self.data_widget.reset()
 

--- a/BaseStation/src/ui/altitude_graph.py
+++ b/BaseStation/src/ui/altitude_graph.py
@@ -1,6 +1,7 @@
 from PyQt5 import QtWidgets, QtCore
 from pyqtgraph import PlotWidget, mkPen, mkBrush, TextItem
 
+from src.data_processing.apogee import Apogee
 from src.ui.utils import set_minimum_expanding_size_policy
 
 
@@ -26,7 +27,6 @@ class AltitudeGraph(PlotWidget):
         self.addItem(self.current_altitude_text, ignoreBounds=True)
 
         self.simulation_curve = self.plot([], [], pen=mkPen(color='b', width=3))
-        self.apogee = 0
         self.draw_apogee_plot = True
         self.apogee_text = TextItem("", anchor=(1, 1), color=(0, 0, 0, 0))
         self.apogee_point = self.plotItem.scatterPlot([], [], pxMode=True, size=9, brush=mkBrush(color='b'))
@@ -51,18 +51,15 @@ class AltitudeGraph(PlotWidget):
     def show_simulation(self, time: list, altitude: list):
         self.simulation_curve.setData(time, altitude)
 
-    def draw_apogee(self, values: list):
-        if len(values) == 2:
-            self.apogee = values[1]
-            apogee_index = values[0]    # FIXME: use timestamps
-
+    def draw_apogee(self, apogee: Apogee):
+        if apogee.is_reached:
             if self.draw_apogee_plot:
                 self.apogee_text.setColor(color='b')
                 self.draw_apogee_plot = False
 
-            # self.apogee_point.setData([apogee_index], [self.apogee])
-            # self.apogee_text.setPos(apogee_index, self.apogee)
-            self.apogee_text.setText("{}ft".format(int(self.apogee)))
+            self.apogee_point.setData([apogee.timestamp], [apogee.altitude])
+            self.apogee_text.setPos(apogee.timestamp, apogee.altitude)
+            self.apogee_text.setText("{}ft".format(int(apogee.altitude)))
         else:
             if not self.draw_apogee_plot:
                 self.reset_apogee()
@@ -81,7 +78,6 @@ class AltitudeGraph(PlotWidget):
         self.current_altitude_text.setColor(color=(0, 0, 0, 0))
 
     def reset_apogee(self):
-        self.apogee = 0
         self.apogee_point.clear()
         self.apogee_text.setColor(color=(0, 0, 0, 0))
         self.draw_apogee_plot = True

--- a/BaseStation/src/ui/altitude_graph.py
+++ b/BaseStation/src/ui/altitude_graph.py
@@ -32,12 +32,6 @@ class AltitudeGraph(PlotWidget):
         self.apogee_point = self.plotItem.scatterPlot([], [], pxMode=True, size=9, brush=mkBrush(color='b'))
         self.addItem(self.apogee_text, ignoreBounds=True)
 
-    def paintEvent(self, ev):
-        self.apogee_text.setText("{}ft".format(int(self.apogee)))
-        self.current_altitude_text.setText("{}ft".format(self.current_altitude))
-
-        super(AltitudeGraph, self).paintEvent(ev)
-
     def draw_altitude_curve(self, timestamps: list, altitudes: list):
         nb_points = len(altitudes)
 
@@ -49,6 +43,7 @@ class AltitudeGraph(PlotWidget):
             self.current_altitude_point.setData([self.current_timestamp], [self.current_altitude])
             self.current_altitude_text.setPos(self.current_timestamp, self.current_altitude)
             self.current_altitude_text.setColor(color='k')
+            self.current_altitude_text.setText("{}ft".format(self.current_altitude))
 
     def set_target_altitude(self, altitude):
         self.plotItem.addLine(y=altitude, pen=mkPen(color=(15, 236, 20), width=3, style=QtCore.Qt.DashDotLine))
@@ -67,6 +62,7 @@ class AltitudeGraph(PlotWidget):
 
             # self.apogee_point.setData([apogee_index], [self.apogee])
             # self.apogee_text.setPos(apogee_index, self.apogee)
+            self.apogee_text.setText("{}ft".format(int(self.apogee)))
         else:
             if not self.draw_apogee_plot:
                 self.reset_apogee()

--- a/BaseStation/src/ui/data_widget.py
+++ b/BaseStation/src/ui/data_widget.py
@@ -3,6 +3,7 @@ from PyQt5 import QtCore
 from PyQt5 import QtWidgets
 from PyQt5.QtWidgets import QLabel
 
+from src.data_processing.apogee import Apogee
 from src.data_processing.gps.gps_coordinates import GpsCoordinates
 from src.data_processing.orientation.orientation import Orientation
 from src.openrocket_simulation import OpenRocketSimulation
@@ -204,8 +205,8 @@ class DataWidget(QtWidgets.QWidget):
     def draw_altitude(self, timestamps: list, altitudes: list):
         self.altitude_graph.draw_altitude_curve(timestamps, altitudes)
 
-    def draw_apogee(self, values: list):
-        self.altitude_graph.draw_apogee(values)
+    def draw_apogee(self, apogee: Apogee):
+        self.altitude_graph.draw_apogee(apogee)
 
     def draw_map(self, eastings: list, northings: list):
         self.map.draw_map(eastings, northings)

--- a/BaseStation/tests/builders/config_builder.py
+++ b/BaseStation/tests/builders/config_builder.py
@@ -18,10 +18,14 @@ class ConfigBuilder:
         self.timeout = 1
 
         self.target_altitude = 10000
-        self.gui_fps = 30
+        self.gui_fps = 30.0
 
     def with_rocket_packet_version(self, version: int):
         self.rocket_packet_version = version
+        return self
+
+    def with_gui_fps(self, frame_per_second: float):
+        self.gui_fps = frame_per_second
         return self
 
     def build(self):

--- a/BaseStation/tests/data_processing/test_apogee.py
+++ b/BaseStation/tests/data_processing/test_apogee.py
@@ -1,47 +1,18 @@
 import unittest
 
-from src.data_processing.apogee_calculator import ApogeeCalculator
+from src.data_processing.apogee import Apogee
 
 
-class TestApogee(unittest.TestCase):
+class ApogeeTest(unittest.TestCase):
+    TIMESTAMP = 60.0
+    ALTITUDE = 10000.0
 
-    def setUp(self):
-        self.apogee_calculator = ApogeeCalculator()
+    def test_apogee_is_reached_when_created_from_constructor(self):
+        apogee = Apogee(self.TIMESTAMP, self.ALTITUDE)
 
-    def test_update_one_apogee(self):
-        points = [0, 100, 194, 256, 500, 804, 300]
-        self.apogee_calculator.update(points)
+        self.assertTrue(apogee.is_reached)
 
-        self.assertEqual(self.apogee_calculator.get_apogee(), (5, 804))
+    def test_apogee_is_not_reached_when_created_from_unreached_method(self):
+        apogee = Apogee.unreached()
 
-    def test_update_distinguish_real_apogee(self):
-        points = [0, 100, 194, 256, 500, 804, 300, 1000, 600, 9]
-        self.apogee_calculator.update(points)
-
-        self.assertEqual(self.apogee_calculator.get_apogee(), (7, 1000))
-
-    def test_update_no_apogee(self):
-        points = [0, 100, 194]
-        self.apogee_calculator.update(points)
-
-        self.assertIsNone(self.apogee_calculator.get_apogee())
-
-    def test_has_apogee_fail_with_one_point(self):
-        points = [2]
-        self.apogee_calculator.update(points)
-        self.assertIsNone(self.apogee_calculator.get_apogee())
-
-    def test_empty_apogee(self):
-        points = []
-        self.apogee_calculator.update(points)
-        self.assertIsNone(self.apogee_calculator.get_apogee())
-
-    def test_loop_integration(self):
-        points = []
-        points_fill = [0, 100, 5000, 10000, 9000, 5000, 40]
-
-        for i in range(len(points_fill)):
-            points.append(points_fill[i])
-            self.apogee_calculator.update(points)
-
-        self.assertEqual(self.apogee_calculator.get_apogee(), (3, 10000))
+        self.assertFalse(apogee.is_reached)

--- a/BaseStation/tests/data_processing/test_apogee_calculator.py
+++ b/BaseStation/tests/data_processing/test_apogee_calculator.py
@@ -1,0 +1,67 @@
+import unittest
+
+from src.data_processing.apogee import Apogee
+from src.data_processing.apogee_calculator import ApogeeCalculator
+
+
+class ApogeeCalculatorTest(unittest.TestCase):
+
+    def setUp(self):
+        self.apogee_calculator = ApogeeCalculator()
+
+    def test_update_one_apogee(self):
+        points = [0, 100, 194, 256, 500, 804, 300]
+        timestamps = self._generate_timestamps_for(points)
+
+        self.apogee_calculator.update(timestamps, points)
+
+        self.assertEqual(self.apogee_calculator.get_apogee(), Apogee(5, 804))
+
+    def test_update_distinguish_real_apogee(self):
+        points = [0, 100, 194, 256, 500, 804, 300, 1000, 600, 9]
+        timestamps = self._generate_timestamps_for(points)
+
+        self.apogee_calculator.update(timestamps, points)
+
+        self.assertEqual(self.apogee_calculator.get_apogee(), Apogee(7, 1000))
+
+    def test_update_no_apogee(self):
+        points = [0, 100, 194]
+        timestamps = self._generate_timestamps_for(points)
+
+        self.apogee_calculator.update(timestamps, points)
+
+        self.assertEqual(self.apogee_calculator.get_apogee(), Apogee.unreached())
+
+    def test_has_apogee_fail_with_one_point(self):
+        points = [2]
+        timestamps = self._generate_timestamps_for(points)
+
+        self.apogee_calculator.update(timestamps, points)
+
+        self.assertEqual(self.apogee_calculator.get_apogee(), Apogee.unreached())
+
+    def test_empty_apogee(self):
+        points = []
+        timestamps = self._generate_timestamps_for(points)
+
+        self.apogee_calculator.update(timestamps, points)
+
+        self.assertEqual(self.apogee_calculator.get_apogee(), Apogee.unreached())
+
+    def test_loop_integration(self):
+        timestamps = []
+        points = []
+        points_fill = [0, 100, 5000, 10000, 9000, 5000, 40]
+
+        for i in range(len(points_fill)):
+            timestamps.append(i)
+            points.append(points_fill[i])
+
+            self.apogee_calculator.update(timestamps, points)
+
+        self.assertEqual(self.apogee_calculator.get_apogee(), Apogee(3, 10000))
+
+    @staticmethod
+    def _generate_timestamps_for(points):
+        return [i for i in range(len(points))]

--- a/BaseStation/tests/test_controller.py
+++ b/BaseStation/tests/test_controller.py
@@ -160,7 +160,7 @@ class ControllerTest(unittest.TestCase):
         self.assertEqual(self.controller.consumer, self.consumer)
 
     def setup_consumer_data(self):
-        data = {"altitude_feet": self.ALTITUDES, "apogee": self.APOGEE, "voltage": self.VOLTAGE,
+        data = {"altitude_feet": self.ALTITUDES, "voltage": self.VOLTAGE,
                 "acquisition_board_state_1": [self.BOARD_STATE_1], "acquisition_board_state_2": [self.BOARD_STATE_2],
                 "acquisition_board_state_3": [self.BOARD_STATE_3], "power_supply_state_1": [self.POWER_SUPPLY_STATE_1],
                 "power_supply_state_2": [self.POWER_SUPPLY_STATE_2],
@@ -168,6 +168,7 @@ class ControllerTest(unittest.TestCase):
         self.consumer.__getitem__.side_effect = lambda arg: data[arg]
         self.consumer.get_projected_coordinates.return_value = (self.EASTINGS, self.NORTHINGS)
         self.consumer.get_last_gps_coordinates.return_value = self.GPS_COORDINATES
+        self.consumer.get_apogee.return_value = self.APOGEE
 
     def assert_leds_updated(self):
         calls = [call(1, self.BOARD_STATE_1), call(2, self.BOARD_STATE_2), call(3, self.BOARD_STATE_3),


### PR DESCRIPTION
- Utilisation d'un QTimer pour que les updates du UI soient faites dans l'event loop de QT;
- Création d'un value object `Apogee` pour remplacer le tuple utilisé pour représenté l'apogé, ce qui simplifie la validation de l'atteinte de l'apogée;
- La classe `AltitudeGraph` utilise maintenant des timestamps pour son axe des x plutôt que le nombre de packets.

J'ai choisi de garder les controllers qui poussent les données vers le UI plutôt que de les remplacer par une architecture où ce sont les composantes du UI qui tirent les données quand elles s'updatent afin de limiter les changements.

Complète #89 et #39.
